### PR TITLE
feat: set annotation end time for open incidents

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -50,6 +50,36 @@ describe('API testing', () => {
     await directDs.query(defaultQuery);
   });
 
+  it('When incident is not resolved yet, the annotation end time should be the same as the time frame end time', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockReturnValue(of(createOpenIncidentPagerdutyResponse()));
+    const instanceSettings = {
+      url: 'proxied',
+      directUrl: 'direct',
+      user: 'test',
+      password: 'mupp',
+      access: 'direct',
+      jsonData: {
+        customQueryParameters: '',
+      },
+    } as unknown as DataSourceInstanceSettings<MyDataSourceOptions>;
+    const directDs = new DataSource(instanceSettings);
+
+    const expectedResponse = new MutableDataFrame({
+      refId: 'refId',
+      fields: [
+        { config: {}, name: 'time', values: [1444167042000], type: FieldType.time },
+        { config: {}, name: 'timeEnd', values: [defaultQuery.range.to.toDate().getTime()], type: FieldType.time },
+        { config: {}, name: 'title', values: ['The server is on fire.'], type: FieldType.string },
+        { config: {}, name: 'text', values: ['[#1234] The server is on fire.'], type: FieldType.string },
+        { config: {}, name: 'id', values: ['baf7cf21b1da41b4b0221008339ff357'], type: FieldType.string },
+      ],
+    });
+
+    const result = await directDs.query(defaultQuery);
+    expect(JSON.stringify(result.data)).toEqual(JSON.stringify([expectedResponse]));
+  });
+
   it('Query returns expected DatadFrame', async () => {
     fetchMock.mockReset();
     fetchMock.mockReturnValue(of(createDefaultPagerdutyResponse()));
@@ -123,10 +153,25 @@ describe('Pagination tests', () => {
       refId: 'refId',
       fields: [
         { config: {}, name: 'time', values: [1444167042000, 1475789442000], type: FieldType.time },
-        { config: {}, name: 'timeEnd', values: [1444167503000,1475789903000], type: FieldType.time },
-        { config: {}, name: 'title', values: ['The server is on fire.', 'The server is under water.'], type: FieldType.string },
-        { config: {}, name: 'text', values: ['[#1234] The server is on fire.', '[#5678] The server is under water.'], type: FieldType.string },
-        { config: {}, name: 'id', values: ['baf7cf21b1da41b4b0221008339ff357', 'testingrandomkey'], type: FieldType.string },
+        { config: {}, name: 'timeEnd', values: [1444167503000, 1475789903000], type: FieldType.time },
+        {
+          config: {},
+          name: 'title',
+          values: ['The server is on fire.', 'The server is under water.'],
+          type: FieldType.string,
+        },
+        {
+          config: {},
+          name: 'text',
+          values: ['[#1234] The server is on fire.', '[#5678] The server is under water.'],
+          type: FieldType.string,
+        },
+        {
+          config: {},
+          name: 'id',
+          values: ['baf7cf21b1da41b4b0221008339ff357', 'testingrandomkey'],
+          type: FieldType.string,
+        },
       ],
     });
 
@@ -318,6 +363,100 @@ function createSecondPaginatedPagerdutyResponse() {
       ],
       limit: 1,
       offset: 1,
+      more: false,
+    },
+  };
+}
+
+function createOpenIncidentPagerdutyResponse() {
+  return {
+    data: {
+      incidents: [
+        {
+          id: 'PT4KHLK',
+          type: 'incident',
+          summary: '[#1234] The server is on fire.',
+          self: 'https://api.pagerduty.com/incidents/PT4KHLK',
+          html_url: 'https://subdomain.pagerduty.com/incidents/PT4KHLK',
+          incident_number: 1234,
+          title: 'The server is on fire.',
+          created_at: '2015-10-06T21:30:42Z',
+          updated_at: '2015-10-06T21:40:23Z',
+          status: 'acknowledged',
+          incident_key: 'baf7cf21b1da41b4b0221008339ff357',
+          service: {
+            id: 'PIJ90N7',
+            type: 'service_reference',
+            summary: 'My Mail Service',
+            self: 'https://api.pagerduty.com/services/PIJ90N7',
+            html_url: 'https://subdomain.pagerduty.com/service-directory/PIJ90N7',
+          },
+          assignments: [],
+          assigned_via: 'escalation_policy',
+          last_status_change_at: '2015-10-06T21:38:23Z',
+          resolved_at: null,
+          first_trigger_log_entry: {
+            id: 'Q02JTSNZWHSEKV',
+            type: 'trigger_log_entry_reference',
+            summary: 'Triggered through the API',
+            self: 'https://api.pagerduty.com/log_entries/Q02JTSNZWHSEKV?incident_id=PT4KHLK',
+            html_url: 'https://subdomain.pagerduty.com/incidents/PT4KHLK/log_entries/Q02JTSNZWHSEKV',
+          },
+          alert_counts: {
+            all: 2,
+            triggered: 0,
+            resolved: 2,
+          },
+          is_mergeable: true,
+          escalation_policy: {
+            id: 'PT20YPA',
+            type: 'escalation_policy_reference',
+            summary: 'Another Escalation Policy',
+            self: 'https://api.pagerduty.com/escalation_policies/PT20YPA',
+            html_url: 'https://subdomain.pagerduty.com/escalation_policies/PT20YPA',
+          },
+          teams: [
+            {
+              id: 'PQ9K7I8',
+              type: 'team_reference',
+              summary: 'Engineering',
+              self: 'https://api.pagerduty.com/teams/PQ9K7I8',
+              html_url: 'https://subdomain.pagerduty.com/teams/PQ9K7I8',
+            },
+          ],
+          pending_actions: [],
+          acknowledgements: [],
+          alert_grouping: {
+            grouping_type: 'advanced',
+            started_at: '2015-10-06T21:30:42Z',
+            ended_at: null,
+            alert_grouping_active: true,
+          },
+          last_status_change_by: {
+            id: 'PXPGF42',
+            type: 'user_reference',
+            summary: 'Earline Greenholt',
+            self: 'https://api.pagerduty.com/users/PXPGF42',
+            html_url: 'https://subdomain.pagerduty.com/users/PXPGF42',
+          },
+          priority: {
+            id: 'P53ZZH5',
+            type: 'priority_reference',
+            summary: 'P2',
+            self: 'https://api.pagerduty.com/priorities/P53ZZH5',
+          },
+          resolve_reason: null,
+          conference_bridge: {
+            conference_number: '+1-415-555-1212,,,,1234#',
+            conference_url: 'https://example.com/acb-123',
+          },
+          incidents_responders: [],
+          responder_requests: [],
+          urgency: 'high',
+        },
+      ],
+      limit: 1,
+      offset: 0,
       more: false,
     },
   };

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -42,7 +42,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
 
       response.incidents.forEach((incident: Incident) => {
         const timestamp: Date = new Date(incident.created_at);
-        const timestamp_end: Date = new Date(incident.resolved_at);
+        const timestamp_end: Date = incident.resolved_at !== null ? new Date(incident.resolved_at) : new Date(to);
         const createdAt = timestamp.getTime();
         const resolvedAt = timestamp_end.getTime();
         const title = incident.title;


### PR DESCRIPTION
Open incidents do not have a resolved_at field, so we choose to set the annotation end time to the end of the time range to account for this case, conveying visually the idea that the incident is still open.

Fixes #6