### PR TITLE
Add screenshot images to plugin.json defintion

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -17,7 +17,16 @@
             "large": "img/pagerduty.svg"
         },
         "links": [],
-        "screenshots": [],
+        "screenshots": [
+            {
+                "name": "Annotation visual example",
+                "path": "img/screenshots/example.png"
+            },
+            {
+                "name": "Query configuration example",
+                "path": "img/screenshots/query.png"
+            }
+        ],
         "version": "%VERSION%",
         "updated": "%TODAY%"
     },


### PR DESCRIPTION
Screenshots added to the plugin.json defintion will be visible in the Catalogue entry for the plugin. The plugin-validator also throws a warning if no screenshot is attached.